### PR TITLE
Fix to ALMA returning too short vector

### DIFF
--- a/R/MovingAverages.R
+++ b/R/MovingAverages.R
@@ -450,5 +450,6 @@ function(x, n=9, offset=0.85, sigma=6, ...) {
   if(sumWeights != 0)
     wts <- wts/sumWeights
   alma <- rollapply(x, width=n, FUN=function(xx) sum(xx*wts), align="right")
+  alma <- c(rep(NA, n-1), alma)
   reclass(alma, x)
 }


### PR DESCRIPTION
ALMA moving average returns vector n-1 too short because of rollapply. It is not consistent with other Moving Averages. That one line should fix it and make it consistent with other MAs.