### PR TITLE
Add other (unused) arguments to DEMA

### DIFF
--- a/R/MovingAverages.R
+++ b/R/MovingAverages.R
@@ -208,7 +208,7 @@ function (x, n=10, wilder=FALSE, ratio=NULL, ...) {
 
 #'@rdname MovingAverages
 "DEMA" <-
-function(x, n=10, v=1, wilder=FALSE, ratio=NULL) {
+function(x, n=10, v=1, wilder=FALSE, ratio=NULL,  ...) {
 
   # Double Exponential Moving Average
   # Thanks to John Gavin for the v-factor generalization


### PR DESCRIPTION
All other moving averages allow passing unused arguments. It allows to loop over many Moving Averages and not change inputs every single time to precisely match arguments. For example "volume" argument used in EVWMA won't be used in DEMA since it uses a different argument "v" but with this change, it won't raise an error.